### PR TITLE
fix(security): Always redirect to the https url

### DIFF
--- a/frontend/frontend.yaml
+++ b/frontend/frontend.yaml
@@ -22,5 +22,7 @@ handlers:
 - url: /
   static_files: static/home.html
   upload: static/home.html
+  secure: always
 - url: /
   static_dir: static
+  secure: always


### PR DESCRIPTION
I have a CORS issue with [http://go-meetups.appspot.com/](http://go-meetups.appspot.com/)

The solution is to always redirect the user to [https://go-meetups.appspot.com/](https://go-meetups.appspot.com/)